### PR TITLE
Fixed META-INF file to avoid persistent update alerts in Protege

### DIFF
--- a/target/classes/META-INF/MANIFEST.MF
+++ b/target/classes/META-INF/MANIFEST.MF
@@ -23,8 +23,8 @@ Bundle-Description: The view offers a more comfortable way to make indiv
   a right click on one of the OWLClasses from tree view.
 Bundle-ManifestVersion: 2
 Bundle-Name: Individual Properties Contextual Assertions
-Bundle-SymbolicName: org.odase.protege.plugin.individualPropertiesContex
- tualAssertions;singleton:=true
+Bundle-SymbolicName: org.odase.protege.individualPropertiesContextualAss
+ ertions;singleton:=true
 Bundle-Vendor: The ODASE Development Team
 Bundle-Version: 1.0.0
 Created-By: Apache Maven Bundle Plugin


### PR DESCRIPTION
Changed the Bundle-SymbolicName from "org.odase.protege.plugin.individualPropertiesContextualAssertions" to "org.odase.protege.individualPropertiesContextualAssertions" to match the plugin id in the update.properties file.

This pull request was created to address the following issue reported on the Protege User mailing list:
http://protege-project.136.n4.nabble.com/Persistent-update-alert-td4671408.html

If the PR is accepted by the owner, to fully fix the problem a new version of the plugin should be created (and the version numbers in the appropriate places should be updated).