### PR TITLE
Fixed broken download link

### DIFF
--- a/update.properties
+++ b/update.properties
@@ -1,7 +1,7 @@
 name=IndividualPropertiesContextualAssertions
 id=org.odase.protege.individualPropertiesContextualAssertions
 version=1.0.2
-download=https://github.com/onor13/odase.protege.plugin.individualPropertiesContextualAssertions/releases/download/v1.0.2/org.odase.protege.plugin.individualPropertiesContextualAssertions-1.0.2.jar
+download=https://github.com/onor13/odase.protege.plugin.individualPropertiesContextualAssertions/releases/download/v1.0.2/org.odase.protege.individualPropertiesContextualAssertions-1.0.2.jar
 readme=https://raw.githubusercontent.com/onor13/odase.protege.plugin.individualPropertiesContextualAssertions/master/readme.html
 license=http://www.gnu.org/licenses/lgpl.html
 author=ODASE


### PR DESCRIPTION
Fixed download link which was not valid any more, after the latest changes in the way the jar file was created.
This is critical for Protege auto-update to work properly!